### PR TITLE
Rename Builder to DependencyBuilder to avoid import conflicts

### DIFF
--- a/example/injector_example.dart
+++ b/example/injector_example.dart
@@ -57,7 +57,7 @@ class TikkrDatabase extends Database {
 }
 
 class CustomFactory<T> extends Factory<T> {
-  CustomFactory(Builder<T> builder) : super(builder);
+  CustomFactory(DependencyBuilder<T> builder) : super(builder);
 
   @override
   T get instance {

--- a/lib/src/factory/factory.dart
+++ b/lib/src/factory/factory.dart
@@ -13,19 +13,19 @@
 ///     return CarImpl(engine: engine);
 /// });
 /// ```
-typedef Builder<T> = T Function();
+typedef DependencyBuilder<T> = T Function();
 
 abstract class Factory<T> {
-  final Builder<T> builder;
+  final DependencyBuilder<T> builder;
 
   Factory(this.builder);
 
   T get instance;
 
-  static Factory<T> provider<T>(Builder<T> builder) =>
+  static Factory<T> provider<T>(DependencyBuilder<T> builder) =>
       _ProviderFactory(builder);
 
-  static Factory<T> singleton<T>(Builder<T> builder) =>
+  static Factory<T> singleton<T>(DependencyBuilder<T> builder) =>
       _SingletonFactory(builder);
 }
 
@@ -33,7 +33,7 @@ abstract class Factory<T> {
 /// always returns a new instance built by the [builder].
 class _ProviderFactory<T> implements Factory<T> {
   @override
-  Builder<T> builder;
+  DependencyBuilder<T> builder;
 
   _ProviderFactory(this.builder);
 
@@ -45,7 +45,7 @@ class _ProviderFactory<T> implements Factory<T> {
 /// returns the same instance when accessing [instance].
 class _SingletonFactory<T> implements Factory<T> {
   @override
-  Builder<T> builder;
+  DependencyBuilder<T> builder;
 
   T? _value;
 

--- a/lib/src/injector_base.dart
+++ b/lib/src/injector_base.dart
@@ -55,7 +55,7 @@ class Injector {
 
   /// Registers the [builder] with a [Factory.singleton] factory.
   void registerSingleton<T>(
-    Builder<T> builder, {
+    DependencyBuilder<T> builder, {
     bool override = false,
     String dependencyName = "",
   }) =>
@@ -64,7 +64,7 @@ class Injector {
 
   /// Registers the [builder] with a [Factory.provider] factory.
   void registerDependency<T>(
-    Builder<T> builder, {
+    DependencyBuilder<T> builder, {
     bool override = false,
     String dependencyName = "",
   }) =>


### PR DESCRIPTION
`Builder` conflicts with the `Builder` widget from Flutter. I renamed it to `DependencyBuilder`.

Open for other name suggestions.